### PR TITLE
Add support for negated filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ From the [available rule set](https://newsboat.org/releases/2.15/docs/newsboat.h
 **Comparison Operators**
 
 - `=~`: test whether regular expression matches
+- `!~`: logical negation of the `=~` operator
 - `#`: contains; this operator matches if a word is contained in a list of space-separated words (useful for matching tags, see below)
+- `!#`: contains not; the negation of the `#` operator
 
 
 


### PR DESCRIPTION
Adds two new filters which will kill the entry if they DO NOT match.

```
!~    logical negation of the =~ operator
!#    contains not; the negation of the # operator
```

Behavior and operators taken from
[newsboat's filter language](https://newsboat.org/releases/2.15/docs/newsboat.html#_filter_language)