### PR TITLE
README: Miniflux now has built-in filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ export MF_KILLFILE_REFRESH_HOURS=2
 ```
 
 There's also a Dockerfile and Docker Compose file included so you can easily run it via `docker-compose -f docker-compose.yml up -d`.
+
+## See Also
+
+Miniflux v2.0.25 added built-in support for [filtering rules](https://miniflux.app/docs/rules.html#filtering-rules).


### PR DESCRIPTION
In case folks aren't aware, this adds a note to the README with a link to Miniflux documentation for its built-in support for block/keep filtering rules.